### PR TITLE
add geometry, add mediumtext and tinytext types for jdl export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,9 @@
         <guava.version>28.0-jre</guava.version>
 
         <skip.jooq.generation>false</skip.jooq.generation>
-        <database.url>jdbc:mysql://localhost:3306/</database.url>
+        <database.url>jdbc:mysql://localhost:3306/?serverTimezone=UTC</database.url>
+        <database.user>root</database.user>
+        <database.password></database.password>
 
         <!--<jacoco-plugin.version>0.7.9</jacoco-plugin.version>-->
         <!--<coveralls-plugin.version>4.3.0</coveralls-plugin.version>-->
@@ -159,8 +161,8 @@
                     <jdbc>
                         <driver>com.mysql.cj.jdbc.Driver</driver>
                         <url>${database.url}</url>
-                        <user>root</user>
-                        <password></password>
+                        <user>${database.user}</user>
+                        <password>${database.password}</password>
                     </jdbc>
                     <generator>
                         <name>org.jooq.codegen.JavaGenerator</name>

--- a/src/main/java/org/blackdread/sqltojava/entity/JdlFieldEnum.java
+++ b/src/main/java/org/blackdread/sqltojava/entity/JdlFieldEnum.java
@@ -26,7 +26,11 @@ public enum JdlFieldEnum {
     /**
      * Defined here to allow to have a pattern set for TIME type of SQL that jdl does not support by default
      */
-    TIME_AS_TEXT;
+    TIME_AS_TEXT,
+    /**
+     * Defined here to allow to have a pattern set for GEOMETRY type of SQL that jdl does not support by default
+     */
+    GEOMETRY_AS_TEXT;
 
     public String toCamelUpper() {
         return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, this.name());

--- a/src/main/java/org/blackdread/sqltojava/service/SqlJdlTypeService.java
+++ b/src/main/java/org/blackdread/sqltojava/service/SqlJdlTypeService.java
@@ -39,7 +39,8 @@ public class SqlJdlTypeService {
             jdlLong().stream(),
             jdlZonedDateTime().stream(),
             jdlTextBlob().stream(),
-            jdlTime().stream()
+            jdlTime().stream(),
+            jdlGeometry().stream()
         ).collect(Collectors.toList());
 
         final HashSet<String> setTotal = new HashSet<>(total);
@@ -105,6 +106,10 @@ public class SqlJdlTypeService {
             return JdlFieldEnum.BIG_DECIMAL;
         }
 
+        if (isTypeContained(jdlGeometry(), type)) {
+            return JdlFieldEnum.GEOMETRY_AS_TEXT;
+        }
+
         throw new IllegalStateException("Unknown type: " + type);
     }
 
@@ -117,11 +122,11 @@ public class SqlJdlTypeService {
     }
 
     protected List<String> jdlString() {
-        return Lists.newArrayList("varchar", "char", "text");
+        return Lists.newArrayList("varchar", "char", "text", "tinytext");
     }
 
     protected List<String> jdlTextBlob() {
-        return Lists.newArrayList("longtext");
+        return Lists.newArrayList("longtext", "mediumtext");
     }
 
     protected List<String> jdlInteger() {
@@ -162,6 +167,17 @@ public class SqlJdlTypeService {
 
     protected List<String> jdlZonedDateTime() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Not support by base jhipster but to export database which has this type.
+     * See:
+     * https://blog.ippon.fr/2017/12/04/la-technologie-spatiale-au-service-de-jhipster/
+     * https://github.com/chegola/jhipster-spatial
+     * https://stackoverflow.com/questions/50122390/integration-of-postgis-with-jhipster
+     **/
+    protected List<String> jdlGeometry() {
+        return Lists.newArrayList("geometry");
     }
 
 

--- a/src/main/java/org/blackdread/sqltojava/service/logic/JdlService.java
+++ b/src/main/java/org/blackdread/sqltojava/service/logic/JdlService.java
@@ -128,6 +128,11 @@ public class JdlService {
                 max = 8;
                 min = 8;
                 break;
+            case GEOMETRY_AS_TEXT:
+                jdlType = JdlFieldEnum.STRING;
+                max = null;
+                min = null;
+                break;
             default:
                 min = null;
                 max = null;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
     datasource:
             type: com.zaxxer.hikari.HikariDataSource
-            url: jdbc:mysql://localhost:3306/?useUnicode=true&characterEncoding=utf8&useSSL=false
+            url: jdbc:mysql://localhost:3306/?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=UTC
             username: root
             password:
             hikari:
@@ -19,6 +19,17 @@ application:
     ignored-table-names:
         - databasechangelog
         - databasechangeloglock
+        - QRTZ_BLOB_TRIGGERS
+        - QRTZ_CALENDARS
+        - QRTZ_CRON_TRIGGERS
+        - QRTZ_FIRED_TRIGGERS
+        - QRTZ_JOB_DETAILS
+        - QRTZ_LOCKS
+        - QRTZ_PAUSED_TRIGGER_GRPS
+        - QRTZ_SCHEDULER_STATE
+        - QRTZ_SIMPLE_TRIGGERS
+        - QRTZ_SIMPROP_TRIGGERS
+        - QRTZ_TRIGGERS
     export:
         path: ./my-project-jdl.jh
         type: jdl


### PR DESCRIPTION
was importing an existing mysql database which had:
geometry
mediumtext

included 
tinytext as that is also inside mysql.

also excluded quatz db tables as these are not part of the datastructure that needs to be looked after by jhipster
also ensured that if mysql is started in non utc time that it does not crash java.