### PR TITLE
Add Support for column with type longblob

### DIFF
--- a/src/main/java/org/blackdread/sqltojava/service/SqlJdlTypeService.java
+++ b/src/main/java/org/blackdread/sqltojava/service/SqlJdlTypeService.java
@@ -74,6 +74,10 @@ public class SqlJdlTypeService {
             return JdlFieldEnum.STRING;
         }
 
+        if (isTypeContained(jdlBlob(), type)) {
+            return JdlFieldEnum.BLOB;
+        }
+
         if (isTypeContained(jdlTextBlob(), type)) {
             return JdlFieldEnum.TEXT_BLOB;
         }
@@ -127,6 +131,10 @@ public class SqlJdlTypeService {
 
     protected List<String> jdlTextBlob() {
         return Lists.newArrayList("longtext", "mediumtext");
+    }
+
+    protected List<String> jdlBlob() {
+        return Lists.newArrayList("tinyblob", "blob", "mediumblob", "longblob");
     }
 
     protected List<String> jdlInteger() {


### PR DESCRIPTION
```
Caused by: java.lang.IllegalStateException: Unknown type: longblob
	at org.blackdread.sqltojava.service.SqlJdlTypeService.sqlTypeToJdlType(SqlJdlTypeService.java:113) ~[classes/:na]
	at org.blackdread.sqltojava.service.logic.JdlService.buildField(JdlService.java:110) ~[classes/:na]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[na:1.8.0_222]

```
From Jhipster JDL doc:
- AnyBlob or just Blob to create a field of the “any” binary type;
- TextBlob to create a field for a CLOB (long text).

So converting TINYBLOB, BLOB, MEDIUMBLOB, and LONGBLOB to jdl blob