### PR TITLE
Fix depenabot errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
 
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
         <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>
-        <liquibase-maven-plugin.version>4.17.2</liquibase-maven-plugin.version>
+        <liquibase-core.version>4.18.0</liquibase-core.version>
+        <liquibase-maven-plugin.version>4.18.0</liquibase-maven-plugin.version>
         <checkstyle.version>10.5.0</checkstyle.version>
         <plugin.checkstyle.goal>check</plugin.checkstyle.goal>
 
@@ -206,7 +207,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>4.17.2</version>
+            <version>${liquibase-core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/resources/jdl/views-liquibase-changeset.yaml
+++ b/src/test/resources/jdl/views-liquibase-changeset.yaml
@@ -34,7 +34,6 @@ databaseChangeLog:
           changes:
               - createView:
                     fullDefinition: false
-                    remarks: VIEW
                     selectQuery: select order_details.order_number AS order_number,
                                         sum((order_details.quantity_ordered * order_details.price_each)) AS total
                                  from order_details


### PR DESCRIPTION
There was a comment added to the view in the liquibase changeset.  I don't think this was being added in Postgres prior to liquibase 4.18.0.  This remark was removed and now all tests pass.

It is unclear why this was working in IntellJ and not on Github.

You can close https://github.com/Blackdread/sql-to-jdl/pull/146 and https://github.com/Blackdread/sql-to-jdl/pull/147 because this PR include the liquibase bump.

