### PR TITLE
Add mustache.java for JDL templating

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
         <checkstyle.version>10.5.0</checkstyle.version>
         <plugin.checkstyle.goal>check</plugin.checkstyle.goal>
         <guava.version>31.1-jre</guava.version>
+        <mustache.compiler.api.version>0.9.10</mustache.compiler.api.version>
+        <org.mapstruct.version>1.5.3.Final</org.mapstruct.version>
         <!--<jacoco-plugin.version>0.7.9</jacoco-plugin.version>-->
         <!--<coveralls-plugin.version>4.3.0</coveralls-plugin.version>-->
     </properties>
@@ -139,7 +141,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
@@ -215,6 +216,16 @@
             <version>${liquibase-core.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>${mustache.compiler.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -278,6 +289,21 @@
                 <configuration>
                     <propertyFileWillOverride>true</propertyFileWillOverride>
                     <propertyFile>src/test/resources/liquibase.properties</propertyFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <!--<plugin>-->

--- a/src/main/java/org/blackdread/sqltojava/entity/JdlEntity.java
+++ b/src/main/java/org/blackdread/sqltojava/entity/JdlEntity.java
@@ -18,7 +18,7 @@ public interface JdlEntity {
 
     Optional<String> getComment();
 
-    boolean isEnum();
+    boolean isEnumEntity();
 
     /**
      * A pure ManyToMany entity only contains 2 columns of foreign keys

--- a/src/main/java/org/blackdread/sqltojava/entity/JdlRelation.java
+++ b/src/main/java/org/blackdread/sqltojava/entity/JdlRelation.java
@@ -22,7 +22,7 @@ public interface JdlRelation {
      *
      * @return an extra comment
      */
-    Optional<String> getExtraRelationComment();
+    Optional<String> getComment();
 
     /**
      * OwnerSideEntityName{ownerRelationName(ownerDisplayField) required} to InverseSideEntityName{inverseSideRelationName(inverseSideDisplayField)}

--- a/src/main/java/org/blackdread/sqltojava/entity/impl/JdlEntityImpl.java
+++ b/src/main/java/org/blackdread/sqltojava/entity/impl/JdlEntityImpl.java
@@ -23,11 +23,11 @@ public class JdlEntityImpl implements JdlEntity, Comparable<JdlEntity> {
 
     private final String comment;
 
-    private final boolean isReadOnly;
+    private final boolean readOnly;
 
-    private final boolean isEnum;
+    private final boolean enumEntity;
 
-    private final boolean isPureManyToMany;
+    private final boolean pureManyToMany;
 
     private final List<JdlRelation> relations;
 
@@ -36,18 +36,18 @@ public class JdlEntityImpl implements JdlEntity, Comparable<JdlEntity> {
         final String tableName,
         final List<JdlField> fields,
         @Nullable final String comment,
-        final boolean isEnum,
-        final boolean isReadOnly,
-        final boolean isPureManyToMany,
+        final boolean enumEntity,
+        final boolean readOnly,
+        final boolean pureManyToMany,
         final List<JdlRelation> relations
     ) {
         this.name = name;
         this.tableName = tableName;
         this.fields = ImmutableList.copyOf(fields);
         this.comment = (StringUtils.isBlank(comment) || "null".equalsIgnoreCase(comment)) ? null : comment;
-        this.isEnum = isEnum;
-        this.isReadOnly = isReadOnly;
-        this.isPureManyToMany = isPureManyToMany;
+        this.enumEntity = enumEntity;
+        this.readOnly = readOnly;
+        this.pureManyToMany = pureManyToMany;
         this.relations = ImmutableList.copyOf(relations);
     }
 
@@ -72,18 +72,18 @@ public class JdlEntityImpl implements JdlEntity, Comparable<JdlEntity> {
     }
 
     @Override
-    public boolean isEnum() {
-        return isEnum;
+    public boolean isEnumEntity() {
+        return enumEntity;
     }
 
     @Override
     public boolean isReadOnly() {
-        return isReadOnly;
+        return readOnly;
     }
 
     @Override
     public boolean isPureManyToMany() {
-        return isPureManyToMany;
+        return pureManyToMany;
     }
 
     @Override
@@ -106,10 +106,10 @@ public class JdlEntityImpl implements JdlEntity, Comparable<JdlEntity> {
             ", comment='" +
             comment +
             '\'' +
-            ", isReadOnly=" +
-            isReadOnly +
+            ", readOnly=" +
+            readOnly +
             ", isEnum=" +
-            isEnum +
+            enumEntity +
             ", relations=" +
             relations +
             '}'

--- a/src/main/java/org/blackdread/sqltojava/entity/impl/JdlFieldImpl.java
+++ b/src/main/java/org/blackdread/sqltojava/entity/impl/JdlFieldImpl.java
@@ -15,39 +15,39 @@ public class JdlFieldImpl implements JdlField {
     private final JdlFieldEnum type;
     private final String name;
     private final String enumEntityName;
-    private final boolean isRequired;
+    private final boolean required;
     private final String comment;
     private final Integer min;
     private final Integer max;
     private final String pattern;
-    private final boolean isNativeEnum;
-    private final boolean isUnique;
-    private final boolean isPrimaryKey;
+    private final Boolean nativeEnum;
+    private final Boolean unique;
+    private final Boolean primaryKey;
 
     public JdlFieldImpl(
         final JdlFieldEnum type,
         final String name,
-        final boolean isRequired,
+        final boolean required,
         @Nullable final String comment,
         @Nullable final Integer min,
         @Nullable final Integer max,
         @Nullable final String pattern,
         @Nullable final String enumEntityName,
-        final boolean isNativeEnum,
-        final boolean isUnique,
-        final boolean isPrimaryKey
+        final boolean nativeEnum,
+        final boolean unique,
+        final boolean primaryKey
     ) {
         this.type = type;
         this.name = name;
-        this.isRequired = isRequired;
+        this.required = required;
         this.comment = (StringUtils.isBlank(comment) || "null".equalsIgnoreCase(comment)) ? null : comment;
         this.min = min;
         this.max = max;
         this.pattern = pattern;
         this.enumEntityName = enumEntityName;
-        this.isNativeEnum = isNativeEnum;
-        this.isUnique = isUnique;
-        this.isPrimaryKey = isPrimaryKey;
+        this.nativeEnum = nativeEnum;
+        this.unique = unique;
+        this.primaryKey = primaryKey;
     }
 
     @Override
@@ -67,7 +67,7 @@ public class JdlFieldImpl implements JdlField {
 
     @Override
     public boolean isRequired() {
-        return isRequired;
+        return required;
     }
 
     @Override
@@ -92,17 +92,17 @@ public class JdlFieldImpl implements JdlField {
 
     @Override
     public boolean isUnique() {
-        return isUnique;
+        return unique;
     }
 
     @Override
     public boolean isPrimaryKey() {
-        return isPrimaryKey;
+        return primaryKey;
     }
 
     @Override
     public boolean isNativeEnum() {
-        return isNativeEnum;
+        return nativeEnum;
     }
 
     @Override
@@ -118,7 +118,7 @@ public class JdlFieldImpl implements JdlField {
             enumEntityName +
             '\'' +
             ", isRequired=" +
-            isRequired +
+            required +
             ", comment='" +
             comment +
             '\'' +
@@ -130,7 +130,7 @@ public class JdlFieldImpl implements JdlField {
             pattern +
             '\'' +
             ", isNativeEnum=" +
-            isNativeEnum +
+            nativeEnum +
             '}'
         );
     }

--- a/src/main/java/org/blackdread/sqltojava/entity/impl/JdlRelationImpl.java
+++ b/src/main/java/org/blackdread/sqltojava/entity/impl/JdlRelationImpl.java
@@ -14,9 +14,9 @@ public class JdlRelationImpl implements JdlRelation, Comparable<JdlRelation> {
 
     private final RelationType relationType;
 
-    private final boolean isBidirectional;
-    private final boolean isOwnerRequired;
-    private final boolean isInverseSideRequired;
+    private final boolean bidirectional;
+    private final boolean ownerRequired;
+    private final boolean inverseSideRequired;
 
     private final String ownerEntityName;
     private final String inverseSideEntityName;
@@ -27,155 +27,15 @@ public class JdlRelationImpl implements JdlRelation, Comparable<JdlRelation> {
     private final String ownerComment;
     private final String inverseSideComment;
     private final String inverseSideRelationName;
-    private final String inverseDisplayField;
+    private final String inverseSideDisplayField;
 
-    private final String extraRelationComment;
-
-    public JdlRelationImpl(
-        final RelationType relationType,
-        final boolean isBidirectional,
-        final boolean isOwnerRequired,
-        final boolean isInverseSideRequired,
-        final String ownerEntityName,
-        final String inverseSideEntityName,
-        final String ownerRelationName
-    ) {
-        this(
-            relationType,
-            isBidirectional,
-            isOwnerRequired,
-            isInverseSideRequired,
-            ownerEntityName,
-            inverseSideEntityName,
-            ownerRelationName,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
-    }
+    private final String comment;
 
     public JdlRelationImpl(
         final RelationType relationType,
-        final boolean isBidirectional,
-        final boolean isOwnerRequired,
-        final boolean isInverseSideRequired,
-        final String ownerEntityName,
-        final String inverseSideEntityName,
-        final String ownerRelationName,
-        @Nullable final String ownerDisplayField
-    ) {
-        this(
-            relationType,
-            isBidirectional,
-            isOwnerRequired,
-            isInverseSideRequired,
-            ownerEntityName,
-            inverseSideEntityName,
-            ownerRelationName,
-            ownerDisplayField,
-            null,
-            null,
-            null,
-            null,
-            null
-        );
-    }
-
-    public JdlRelationImpl(
-        final RelationType relationType,
-        final boolean isBidirectional,
-        final boolean isOwnerRequired,
-        final boolean isInverseSideRequired,
-        final String ownerEntityName,
-        final String inverseSideEntityName,
-        final String ownerRelationName,
-        @Nullable final String ownerDisplayField,
-        @Nullable final String ownerComment
-    ) {
-        this(
-            relationType,
-            isBidirectional,
-            isOwnerRequired,
-            isInverseSideRequired,
-            ownerEntityName,
-            inverseSideEntityName,
-            ownerRelationName,
-            ownerDisplayField,
-            ownerComment,
-            null,
-            null,
-            null,
-            null
-        );
-    }
-
-    public JdlRelationImpl(
-        final RelationType relationType,
-        final boolean isBidirectional,
-        final boolean isOwnerRequired,
-        final boolean isInverseSideRequired,
-        final String ownerEntityName,
-        final String inverseSideEntityName,
-        final String ownerRelationName,
-        @Nullable final String ownerDisplayField,
-        @Nullable final String ownerComment,
-        @Nullable final String inverseSideComment
-    ) {
-        this(
-            relationType,
-            isBidirectional,
-            isOwnerRequired,
-            isInverseSideRequired,
-            ownerEntityName,
-            inverseSideEntityName,
-            ownerRelationName,
-            ownerDisplayField,
-            ownerComment,
-            inverseSideComment,
-            null,
-            null,
-            null
-        );
-    }
-
-    public JdlRelationImpl(
-        final RelationType relationType,
-        final boolean isBidirectional,
-        final boolean isOwnerRequired,
-        final boolean isInverseSideRequired,
-        final String ownerEntityName,
-        final String inverseSideEntityName,
-        final String ownerRelationName,
-        @Nullable final String ownerDisplayField,
-        @Nullable final String ownerComment,
-        @Nullable final String inverseSideComment,
-        @Nullable final String inverseSideRelationName
-    ) {
-        this(
-            relationType,
-            isBidirectional,
-            isOwnerRequired,
-            isInverseSideRequired,
-            ownerEntityName,
-            inverseSideEntityName,
-            ownerRelationName,
-            ownerDisplayField,
-            ownerComment,
-            inverseSideComment,
-            inverseSideRelationName,
-            null,
-            null
-        );
-    }
-
-    public JdlRelationImpl(
-        final RelationType relationType,
-        final boolean isBidirectional,
-        final boolean isOwnerRequired,
-        final boolean isInverseSideRequired,
+        final boolean bidirectional,
+        final boolean ownerRequired,
+        final boolean inverseSideRequired,
         final String ownerEntityName,
         final String inverseSideEntityName,
         final String ownerRelationName,
@@ -183,44 +43,13 @@ public class JdlRelationImpl implements JdlRelation, Comparable<JdlRelation> {
         @Nullable final String ownerComment,
         @Nullable final String inverseSideComment,
         @Nullable final String inverseSideRelationName,
-        @Nullable final String inverseDisplayField
-    ) {
-        this(
-            relationType,
-            isBidirectional,
-            isOwnerRequired,
-            isInverseSideRequired,
-            ownerEntityName,
-            inverseSideEntityName,
-            ownerRelationName,
-            ownerDisplayField,
-            ownerComment,
-            inverseSideComment,
-            inverseSideRelationName,
-            inverseDisplayField,
-            null
-        );
-    }
-
-    public JdlRelationImpl(
-        final RelationType relationType,
-        final boolean isBidirectional,
-        final boolean isOwnerRequired,
-        final boolean isInverseSideRequired,
-        final String ownerEntityName,
-        final String inverseSideEntityName,
-        final String ownerRelationName,
-        @Nullable final String ownerDisplayField,
-        @Nullable final String ownerComment,
-        @Nullable final String inverseSideComment,
-        @Nullable final String inverseSideRelationName,
-        @Nullable final String inverseDisplayField,
-        @Nullable final String extraRelationComment
+        @Nullable final String inverseSideDisplayField,
+        @Nullable final String comment
     ) {
         this.relationType = relationType;
-        this.isBidirectional = isBidirectional;
-        this.isOwnerRequired = isOwnerRequired;
-        this.isInverseSideRequired = isInverseSideRequired;
+        this.bidirectional = bidirectional;
+        this.ownerRequired = ownerRequired;
+        this.inverseSideRequired = inverseSideRequired;
 
         this.ownerEntityName = ownerEntityName;
         this.inverseSideEntityName = inverseSideEntityName;
@@ -236,10 +65,11 @@ public class JdlRelationImpl implements JdlRelation, Comparable<JdlRelation> {
             (StringUtils.isBlank(inverseSideRelationName) || "null".equalsIgnoreCase(inverseSideRelationName))
                 ? null
                 : inverseSideRelationName;
-        this.inverseDisplayField =
-            (StringUtils.isBlank(inverseDisplayField) || "null".equalsIgnoreCase(inverseDisplayField)) ? null : inverseDisplayField;
-        this.extraRelationComment =
-            (StringUtils.isBlank(extraRelationComment) || "null".equalsIgnoreCase(extraRelationComment)) ? null : extraRelationComment;
+        this.inverseSideDisplayField =
+            (StringUtils.isBlank(inverseSideDisplayField) || "null".equalsIgnoreCase(inverseSideDisplayField))
+                ? null
+                : inverseSideDisplayField;
+        this.comment = (StringUtils.isBlank(comment) || "null".equalsIgnoreCase(comment)) ? null : comment;
     }
 
     @Override
@@ -249,17 +79,17 @@ public class JdlRelationImpl implements JdlRelation, Comparable<JdlRelation> {
 
     @Override
     public boolean isBidirectional() {
-        return isBidirectional;
+        return bidirectional;
     }
 
     @Override
     public boolean isOwnerRequired() {
-        return isOwnerRequired;
+        return ownerRequired;
     }
 
     @Override
     public boolean isInverseSideRequired() {
-        return isInverseSideRequired;
+        return inverseSideRequired;
     }
 
     @Override
@@ -273,8 +103,8 @@ public class JdlRelationImpl implements JdlRelation, Comparable<JdlRelation> {
     }
 
     @Override
-    public Optional<String> getExtraRelationComment() {
-        return Optional.ofNullable(extraRelationComment);
+    public Optional<String> getComment() {
+        return Optional.ofNullable(comment);
     }
 
     @Override
@@ -304,7 +134,7 @@ public class JdlRelationImpl implements JdlRelation, Comparable<JdlRelation> {
 
     @Override
     public Optional<String> getInverseSideDisplayField() {
-        return Optional.ofNullable(inverseDisplayField);
+        return Optional.ofNullable(inverseSideDisplayField);
     }
 
     @Override

--- a/src/main/java/org/blackdread/sqltojava/service/logic/JdlService.java
+++ b/src/main/java/org/blackdread/sqltojava/service/logic/JdlService.java
@@ -1,8 +1,6 @@
 package org.blackdread.sqltojava.service.logic;
 
-import static org.blackdread.sqltojava.entity.JdlFieldEnum.ENUM;
-import static org.blackdread.sqltojava.entity.JdlFieldEnum.STRING;
-import static org.blackdread.sqltojava.entity.JdlFieldEnum.UNSUPPORTED;
+import static org.blackdread.sqltojava.entity.JdlFieldEnum.*;
 
 import java.util.List;
 import java.util.Map;
@@ -50,6 +48,10 @@ public class JdlService {
             .map(Optional::get)
             .sorted()
             .collect(Collectors.toList());
+    }
+
+    public List<JdlRelation> getRelations(List<JdlEntity> entities) {
+        return entities.stream().flatMap(e -> e.getRelations().stream()).collect(Collectors.toList());
     }
 
     private boolean isDefaultPrimaryKey(JdlField f) {

--- a/src/main/java/org/blackdread/sqltojava/service/logic/MustacheService.java
+++ b/src/main/java/org/blackdread/sqltojava/service/logic/MustacheService.java
@@ -1,0 +1,78 @@
+package org.blackdread.sqltojava.service.logic;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import com.github.mustachejava.reflect.ReflectionObjectHandler;
+import com.github.mustachejava.util.DecoratedCollection;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Map;
+import org.blackdread.sqltojava.config.ApplicationProperties;
+import org.blackdread.sqltojava.entity.impl.JdlEntityImpl;
+import org.blackdread.sqltojava.entity.impl.JdlFieldImpl;
+import org.blackdread.sqltojava.entity.impl.JdlRelationImpl;
+import org.blackdread.sqltojava.view.mapper.JdlViewMapperImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MustacheService {
+
+    private static final Logger log = LoggerFactory.getLogger(MustacheService.class);
+    private static final String MUSTACHE_EXTENSION = ".mustache";
+    private final MustacheFactory mf;
+
+    private final ApplicationProperties properties;
+
+    public MustacheService(ApplicationProperties properties) {
+        this.mf = getMustacheFactory();
+        this.properties = properties;
+    }
+
+    /**
+     * Load templates from resources/mustache.  The assumed extension is .mustache so only the file name needs to be specified.
+     * @param template
+     * @param context
+     * @return
+     */
+    public String executeTemplate(String template, Map<String, Object> context) {
+        Mustache m = mf.compile(template + MUSTACHE_EXTENSION);
+        try {
+            StringWriter writer = new StringWriter();
+            m.execute(writer, context).flush();
+            return writer.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Create a MustacheFactory with a MapstructBasedObjectHandler
+     * @return MustacheFactory
+     */
+    private MustacheFactory getMustacheFactory() {
+        DefaultMustacheFactory mf = new DefaultMustacheFactory("mustache");
+        mf.setObjectHandler(new MapstructBasedObjectHandler());
+        return mf;
+    }
+
+    /**
+     * Use Mapstruct to map the JDL model to view DTOs for rendering with mustache.java
+     */
+    private class MapstructBasedObjectHandler extends ReflectionObjectHandler {
+
+        private static JdlViewMapperImpl mapper = new JdlViewMapperImpl();
+
+        @Override
+        public Object coerce(Object o) {
+            if (o instanceof JdlEntityImpl) return mapper.entityToView((JdlEntityImpl) o, properties.getUndefinedTypeHandling());
+            if (o instanceof JdlFieldImpl) return mapper.fieldToView((JdlFieldImpl) o);
+            if (o instanceof JdlRelationImpl) return mapper.relationToView((JdlRelationImpl) o);
+            if (o instanceof Collection) return new DecoratedCollection((Collection) o);
+            return super.coerce(o);
+        }
+    }
+}

--- a/src/main/java/org/blackdread/sqltojava/util/JdlUtils.java
+++ b/src/main/java/org/blackdread/sqltojava/util/JdlUtils.java
@@ -87,7 +87,7 @@ public final class JdlUtils {
             builder.append(entity.getComment().get());
             builder.append(" */\n");
         }
-        if (entity.isEnum()) {
+        if (entity.isEnumEntity()) {
             builder.append("enum ");
         } else {
             if (entity.isReadOnly()) {
@@ -123,12 +123,12 @@ public final class JdlUtils {
                     }
                 }
             }
-            if (!entity.isEnum()) {
+            if (!entity.isEnumEntity()) {
                 // remove the last ','
                 builder.deleteCharAt(builder.length() - 2);
             }
             builder.append("}");
-        } else if (entity.isEnum()) {
+        } else if (entity.isEnumEntity()) {
             builder.append(" {}");
         }
         return builder.toString();
@@ -213,7 +213,7 @@ public final class JdlUtils {
         //              User{teamMember(field)}
         //         }
         final StringBuilder builder = new StringBuilder(200);
-        relation.getExtraRelationComment().ifPresent(s -> builder.append("// ").append(s).append("\n"));
+        relation.getComment().ifPresent(s -> builder.append("// ").append(s).append("\n"));
         builder.append("relationship ");
         builder.append(relation.getRelationType().toJdl());
         builder.append(" {\n");

--- a/src/main/java/org/blackdread/sqltojava/util/JdlUtils.java
+++ b/src/main/java/org/blackdread/sqltojava/util/JdlUtils.java
@@ -1,13 +1,9 @@
 package org.blackdread.sqltojava.util;
 
+import java.util.ArrayList;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.StringUtils;
-import org.blackdread.sqltojava.config.UndefinedJdlTypeHandlingEnum;
-import org.blackdread.sqltojava.entity.JdlEntity;
-import org.blackdread.sqltojava.entity.JdlField;
-import org.blackdread.sqltojava.entity.JdlFieldEnum;
-import org.blackdread.sqltojava.entity.JdlRelation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,38 +11,7 @@ public final class JdlUtils {
 
     private static final Logger log = LoggerFactory.getLogger(JdlUtils.class);
 
-    public static final String indent = " ".repeat(4);
-
     private JdlUtils() {}
-
-    @NotNull
-    public static String validationMax(final int max) {
-        return "max(" + max + ")";
-    }
-
-    @NotNull
-    public static String validationMin(final int min) {
-        return "min(" + min + ")";
-    }
-
-    public static String validationMaxLength(final int max) {
-        return "maxlength(" + max + ")";
-    }
-
-    @NotNull
-    public static String validationMinLength(final int min) {
-        return "minlength(" + min + ")";
-    }
-
-    @NotNull
-    public static String validationRequired() {
-        return "required";
-    }
-
-    @NotNull
-    public static String validationPattern(final String pattern) {
-        return "pattern(/" + pattern + "/)";
-    }
 
     @NotNull
     public static String paginationAll() {
@@ -73,207 +38,6 @@ public final class JdlUtils {
         return "filter *";
     }
 
-    @NotNull
-    public static String unique() {
-        return "unique";
-    }
-
-    @NotNull
-    public static String writeEntity(final JdlEntity entity, UndefinedJdlTypeHandlingEnum undefinedJdlTypeHandling) {
-        final StringBuilder builder = new StringBuilder(500);
-
-        if (entity.getComment().isPresent()) {
-            builder.append("/** ");
-            builder.append(entity.getComment().get());
-            builder.append(" */\n");
-        }
-        if (entity.isEnumEntity()) {
-            builder.append("enum ");
-        } else {
-            if (entity.isReadOnly()) {
-                builder.append("@readOnly\n");
-            }
-            builder.append("entity ");
-        }
-
-        builder.append(entity.getName());
-        if (entity.getTableName() != null) {
-            builder.append("(");
-            builder.append(entity.getTableName());
-            builder.append(")");
-        }
-
-        if (!entity.getFields().isEmpty()) {
-            builder.append(" {\n");
-            for (final JdlField field : entity.getFields()) {
-                switch (field.getType()) {
-                    case UNSUPPORTED -> {
-                        switch (undefinedJdlTypeHandling) {
-                            case UNSUPPORTED -> {
-                                builder.append(writeField(field));
-                                builder.append(",\n");
-                            }
-                            case SKIP -> log.warn("Skipping unsupportd field {}", field);
-                            case ERROR -> throw new RuntimeException(String.format("Unsupported jdl type {}", field));
-                        }
-                    }
-                    default -> {
-                        builder.append(writeField(field));
-                        builder.append(",\n");
-                    }
-                }
-            }
-            if (!entity.isEnumEntity()) {
-                // remove the last ','
-                builder.deleteCharAt(builder.length() - 2);
-            }
-            builder.append("}");
-        } else if (entity.isEnumEntity()) {
-            builder.append(" {}");
-        }
-        return builder.toString();
-    }
-
-    @NotNull
-    public static String writeField(final JdlField field) {
-        final StringBuilder builder = new StringBuilder(200);
-        if (field.getComment().isPresent()) {
-            builder.append(indent);
-            builder.append("/** ");
-            builder.append(field.getComment().get());
-            builder.append(" */\n");
-        }
-        builder.append(indent);
-        builder.append(field.getName());
-        builder.append(" ");
-        JdlFieldEnum type = field.getType();
-        switch (type) {
-            case ENUM:
-                builder.append(
-                    field
-                        .getEnumEntityName()
-                        .orElseThrow(() -> new IllegalStateException("An enum field must have its enum entity name set"))
-                );
-                break;
-            default:
-                builder.append(("UUID".equals(type.name())) ? type.name() : type.toCamelUpper());
-        }
-
-        if (field.isRequired() && !(field.getName().equals("id") && field.getType().equals(JdlFieldEnum.UUID))) {
-            builder.append(" ");
-            builder.append(validationRequired());
-        }
-
-        if (field.isUnique()) {
-            builder.append(" ");
-            builder.append(unique());
-        }
-
-        if (field.getMin().isPresent()) {
-            builder.append(" ");
-            if (field.getType().equals(JdlFieldEnum.STRING)) {
-                builder.append(validationMinLength(field.getMin().get()));
-            } else {
-                builder.append(validationMin(field.getMin().get()));
-            }
-        }
-        if (field.getMax().isPresent()) {
-            builder.append(" ");
-
-            if (field.getType().equals(JdlFieldEnum.STRING)) {
-                builder.append(validationMaxLength(field.getMax().get()));
-            } else {
-                builder.append(validationMax(field.getMax().get()));
-            }
-        }
-        if (field.getPattern().isPresent()) {
-            builder.append(" ");
-            builder.append(validationPattern(field.getPattern().get()));
-        }
-        return builder.toString();
-    }
-
-    /**
-     * Specific for pure ManyToMany relation table
-     *
-     * @param relation Relation MtM
-     * @return Jdl representation of the relation
-     */
-    @NotNull
-    public static String writeRelationPureManyToMany(final JdlRelation relation) {
-        return ("// TODO This is a pure ManyToMany relation (delete me and decide owner side)\n" + writeRelation(relation));
-    }
-
-    @NotNull
-    public static String writeRelation(final JdlRelation relation) {
-        //         relationship ManyToOne {
-        //              /** comment */
-        //              TeamMember{user(login) required} to
-        //              /** comment */
-        //              User{teamMember(field)}
-        //         }
-        final StringBuilder builder = new StringBuilder(200);
-        relation.getComment().ifPresent(s -> builder.append("// ").append(s).append("\n"));
-        builder.append("relationship ");
-        builder.append(relation.getRelationType().toJdl());
-        builder.append(" {\n");
-        relation
-            .getOwnerComment()
-            .ifPresent(ownerComment -> {
-                builder.append(indent);
-                builder.append("/** ");
-                builder.append(relation.getOwnerComment().get());
-                builder.append(" */\n");
-            });
-        builder.append(indent);
-        builder.append(relation.getOwnerEntityName());
-        builder.append("{");
-        builder.append(relation.getOwnerRelationName());
-        relation
-            .getOwnerDisplayField()
-            .ifPresent(ownerDisplayField -> {
-                builder.append("(");
-                builder.append(ownerDisplayField);
-                builder.append(")");
-            });
-        if (relation.isOwnerRequired()) {
-            builder.append(" required");
-        }
-        builder.append("} to");
-
-        if (relation.getInverseSideComment().isPresent()) {
-            builder.append("\n").append(indent).append("/** ");
-            builder.append(relation.getInverseSideComment().get());
-            builder.append(" */\n");
-            builder.append(indent);
-        } else builder.append(" ");
-
-        builder.append(relation.getInverseSideEntityName());
-        if (relation.isBidirectional()) {
-            builder.append("{");
-            builder.append(
-                relation
-                    .getInverseSideRelationName()
-                    .orElseThrow(() -> new IllegalStateException("A bidirectional relation has to have a inverse side relation name"))
-            );
-            relation
-                .getInverseSideDisplayField()
-                .ifPresent(inverseSideDisplayField -> {
-                    builder.append("(");
-                    builder.append(inverseSideDisplayField);
-                    builder.append(")");
-                });
-            if (relation.isInverseSideRequired()) {
-                builder.append(" required");
-            }
-            builder.append("}");
-        }
-        builder.append("\n");
-        builder.append("}");
-
-        return builder.toString();
-    }
-
     public static String getEntityName(String name, List<String> prefixes) {
         String entityName = prefixes
             .stream()
@@ -288,5 +52,14 @@ public final class JdlUtils {
         char c[] = string.toCharArray();
         c[0] = Character.toLowerCase(c[0]);
         return new String(c);
+    }
+
+    public static List<String> getOptions() {
+        List<String> options = new ArrayList<>();
+        options.add(JdlUtils.serviceClassAll());
+        options.add(JdlUtils.paginationAll());
+        options.add(JdlUtils.mapStructAll());
+        options.add(JdlUtils.filterAll());
+        return options;
     }
 }

--- a/src/main/java/org/blackdread/sqltojava/view/JdlCommentView.java
+++ b/src/main/java/org/blackdread/sqltojava/view/JdlCommentView.java
@@ -1,0 +1,26 @@
+package org.blackdread.sqltojava.view;
+
+import java.util.Optional;
+
+/**
+ * Methods for comments in the view
+ */
+public interface JdlCommentView {
+    Optional<String> getComment();
+
+    default String getImplComment(String comment) {
+        return (comment != null) ? "// " + comment : null;
+    }
+
+    default String getDocComment(String comment) {
+        return (comment != null) ? "/** " + comment + " */" : null;
+    }
+
+    default String getDocComment() {
+        return getDocComment(getComment().orElse(null));
+    }
+
+    default String getImplComment() {
+        return getImplComment(getComment().orElse(null));
+    }
+}

--- a/src/main/java/org/blackdread/sqltojava/view/JdlEntityView.java
+++ b/src/main/java/org/blackdread/sqltojava/view/JdlEntityView.java
@@ -1,0 +1,64 @@
+package org.blackdread.sqltojava.view;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.blackdread.sqltojava.config.UndefinedJdlTypeHandlingEnum;
+import org.blackdread.sqltojava.entity.JdlEntity;
+import org.blackdread.sqltojava.entity.JdlField;
+import org.slf4j.Logger;
+
+/**
+ * Methods for JDL entities in the view
+ */
+public interface JdlEntityView extends JdlEntity, JdlCommentView {
+    UndefinedJdlTypeHandlingEnum getUndefinedJdlTypeHandling();
+
+    default String getType() {
+        return (isEnumEntity()) ? "enum" : "entity";
+    }
+
+    default String tableName() {
+        return (getTableName() != null) ? String.format("(%s)", getTableName()) : null;
+    }
+
+    default List<JdlField> filteredFields() {
+        return getFields().stream().filter(f -> filterUnsupported(getUndefinedJdlTypeHandling(), f)).collect(Collectors.toList());
+    }
+
+    /**
+     * Filters fields and throws error based on UndefinedJdlTypeHandling
+     * @return
+     */
+    default boolean filterUnsupported(UndefinedJdlTypeHandlingEnum undefinedJdlTypeHandling, JdlField field) {
+        switch (field.getType()) {
+            case UNSUPPORTED -> {
+                switch (undefinedJdlTypeHandling) {
+                    case UNSUPPORTED -> {
+                        return true;
+                    }
+                    case SKIP -> {
+                        log().warn("Skipping unsupportd field {}", field);
+                        return false;
+                    }
+                    case ERROR -> throw new RuntimeException(String.format("Unsupported jdl type %s", field));
+                    default -> throw new RuntimeException(
+                        String.format("Unhandled UndefinedJdlTypeHandlingEnum.{}", undefinedJdlTypeHandling)
+                    );
+                }
+            }
+            default -> {
+                return true;
+            }
+        }
+    }
+
+    private static Logger log() {
+        final class LogHolder {
+
+            private static final Logger LOGGER = getLogger(JdlEntityView.class);
+        }
+        return LogHolder.LOGGER;
+    }
+}

--- a/src/main/java/org/blackdread/sqltojava/view/JdlFieldView.java
+++ b/src/main/java/org/blackdread/sqltojava/view/JdlFieldView.java
@@ -1,0 +1,95 @@
+package org.blackdread.sqltojava.view;
+
+import com.google.common.base.Joiner;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import org.blackdread.sqltojava.entity.JdlField;
+import org.blackdread.sqltojava.entity.JdlFieldEnum;
+
+/**
+ * Methods for JDL fields in the view
+ */
+public interface JdlFieldView extends JdlField, JdlCommentView {
+    //TODO This validation should be handled in JdlService
+    default String getTypeName() {
+        JdlFieldEnum type = getType();
+        return switch (type) {
+            case ENUM -> getEnumEntityName()
+                .orElseThrow(() -> new IllegalStateException("An enum field must have its enum entity name set"));
+            default -> (("UUID".equals(type.name())) ? type.name() : type.toCamelUpper());
+        };
+    }
+
+    default String constraints() {
+        List<String> constraints = new ArrayList<>();
+        if (renderRequired()) constraints.add(requiredConstraint());
+        if (isUnique()) constraints.add(uniqueConstraint());
+        getMin().ifPresent(min -> constraints.add(minConstraint(min)));
+        getMax().ifPresent(max -> constraints.add(maxConstraint(max)));
+        getPattern().ifPresent(pattern -> constraints.add(patternConstraint(pattern)));
+        return (!constraints.isEmpty()) ? " ".concat(Joiner.on(" ").join(constraints)) : null;
+    }
+
+    // TODO do not write required when field is primary key
+    default boolean renderRequired() {
+        // if (!isPrimaryKey() && isRequired() && ) constraints.add(JdlUtils.validationRequired());
+        return isRequired() && !(getName().equals("id") && getType().equals(JdlFieldEnum.UUID));
+    }
+
+    @NotNull
+    default String requiredConstraint() {
+        return "required";
+    }
+
+    @NotNull
+    default String uniqueConstraint() {
+        return "unique";
+    }
+
+    default String minConstraint(int min) {
+        return switch (getType()) {
+            case STRING -> validationMinLength(min);
+            default -> validationMin(min);
+        };
+    }
+
+    default String maxConstraint(int max) {
+        return switch (getType()) {
+            case STRING -> validationMaxLength(max);
+            default -> validationMax(max);
+        };
+    }
+
+    //TODO This validation should be handled in JdlService
+    default String patternConstraint(String pattern) {
+        return switch (getType()) {
+            case STRING -> validationPattern(pattern);
+            default -> throw new RuntimeException("Only String can have a pattern");
+        };
+    }
+
+    @NotNull
+    default String validationMax(final int max) {
+        return "max(" + max + ")";
+    }
+
+    @NotNull
+    default String validationMin(final int min) {
+        return "min(" + min + ")";
+    }
+
+    default String validationMaxLength(final int max) {
+        return "maxlength(" + max + ")";
+    }
+
+    @NotNull
+    default String validationMinLength(final int min) {
+        return "minlength(" + min + ")";
+    }
+
+    @NotNull
+    default String validationPattern(final String pattern) {
+        return "pattern(/" + pattern + "/)";
+    }
+}

--- a/src/main/java/org/blackdread/sqltojava/view/JdlRelationView.java
+++ b/src/main/java/org/blackdread/sqltojava/view/JdlRelationView.java
@@ -1,0 +1,55 @@
+package org.blackdread.sqltojava.view;
+
+import java.util.Optional;
+import org.blackdread.sqltojava.entity.JdlRelation;
+import org.blackdread.sqltojava.entity.RelationType;
+
+/**
+ * Methods for JDL relations in the view
+ */
+public interface JdlRelationView extends JdlRelation, JdlCommentView {
+    default String getType() {
+        return getRelationType().toJdl();
+    }
+
+    default boolean isPureManyToMany() {
+        return getRelationType() == RelationType.ManyToMany;
+    }
+
+    default String getOwnerDocComment() {
+        return getDocComment(getOwnerComment().orElse(null));
+    }
+
+    default boolean hasComments() {
+        return getOwnerComment().isPresent() || getInverseSideComment().isPresent();
+    }
+
+    default String getInverseDocComment() {
+        return getDocComment(getInverseSideComment().orElse(null));
+    }
+
+    default String getOwnerConfig() {
+        return "{" + getOwnerRelationName() + getRelationConfig(getOwnerDisplayField(), isOwnerRequired()) + "}";
+    }
+
+    default String getInverseConfig() {
+        if (isBidirectional()) {
+            return (
+                "{" +
+                getInverseSideRelationName().orElse("") +
+                getRelationConfig(getInverseSideDisplayField(), isInverseSideRequired()) +
+                "}"
+            );
+        } else {
+            return null;
+        }
+    }
+
+    default String getDisplayField(Optional<String> relation) {
+        return relation.map(displayName -> "(" + displayName + ")").orElse("");
+    }
+
+    default String getRelationConfig(Optional<String> relation, boolean required) {
+        return getDisplayField(relation) + ((required) ? " required" : "");
+    }
+}

--- a/src/main/java/org/blackdread/sqltojava/view/impl/JdlEntityViewImpl.java
+++ b/src/main/java/org/blackdread/sqltojava/view/impl/JdlEntityViewImpl.java
@@ -1,0 +1,53 @@
+package org.blackdread.sqltojava.view.impl;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.blackdread.sqltojava.config.UndefinedJdlTypeHandlingEnum;
+import org.blackdread.sqltojava.entity.JdlField;
+import org.blackdread.sqltojava.entity.JdlRelation;
+import org.blackdread.sqltojava.entity.impl.JdlEntityImpl;
+import org.blackdread.sqltojava.view.JdlEntityView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Immutable
+@ThreadSafe
+public class JdlEntityViewImpl extends JdlEntityImpl implements JdlEntityView {
+
+    private static final Logger log = LoggerFactory.getLogger(JdlEntityViewImpl.class);
+
+    private final UndefinedJdlTypeHandlingEnum undefinedJdlTypeHandling;
+
+    /**
+     * Constructory based on super
+     * @param name
+     * @param tableName
+     * @param fields
+     * @param comment
+     * @param enumEntity
+     * @param readOnly
+     * @param pureManyToMany
+     * @param relations
+     */
+    public JdlEntityViewImpl(
+        String name,
+        String tableName,
+        List<JdlField> fields,
+        @Nullable String comment,
+        boolean enumEntity,
+        boolean readOnly,
+        boolean pureManyToMany,
+        List<JdlRelation> relations,
+        UndefinedJdlTypeHandlingEnum undefinedJdlTypeHandling
+    ) {
+        super(name, tableName, fields, comment, enumEntity, readOnly, pureManyToMany, relations);
+        this.undefinedJdlTypeHandling = undefinedJdlTypeHandling;
+    }
+
+    @Override
+    public UndefinedJdlTypeHandlingEnum getUndefinedJdlTypeHandling() {
+        return undefinedJdlTypeHandling;
+    }
+}

--- a/src/main/java/org/blackdread/sqltojava/view/impl/JdlFieldViewImpl.java
+++ b/src/main/java/org/blackdread/sqltojava/view/impl/JdlFieldViewImpl.java
@@ -1,0 +1,48 @@
+package org.blackdread.sqltojava.view.impl;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.blackdread.sqltojava.entity.JdlFieldEnum;
+import org.blackdread.sqltojava.entity.impl.JdlFieldImpl;
+import org.blackdread.sqltojava.service.logic.JdlService;
+import org.blackdread.sqltojava.view.JdlFieldView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Immutable
+@ThreadSafe
+public class JdlFieldViewImpl extends JdlFieldImpl implements JdlFieldView {
+
+    private static final Logger log = LoggerFactory.getLogger(JdlService.class);
+
+    /**
+     * Constructory based on super
+     * @param type
+     * @param name
+     * @param required
+     * @param comment
+     * @param min
+     * @param max
+     * @param pattern
+     * @param enumEntityName
+     * @param nativeEnum
+     * @param unique
+     * @param primaryKey
+     */
+    public JdlFieldViewImpl(
+        JdlFieldEnum type,
+        String name,
+        boolean required,
+        @Nullable String comment,
+        @Nullable Integer min,
+        @Nullable Integer max,
+        @Nullable String pattern,
+        @Nullable String enumEntityName,
+        Boolean nativeEnum,
+        Boolean unique,
+        Boolean primaryKey
+    ) {
+        super(type, name, required, comment, min, max, pattern, enumEntityName, nativeEnum, unique, primaryKey);
+    }
+}

--- a/src/main/java/org/blackdread/sqltojava/view/impl/JdlRelationViewImpl.java
+++ b/src/main/java/org/blackdread/sqltojava/view/impl/JdlRelationViewImpl.java
@@ -1,0 +1,61 @@
+package org.blackdread.sqltojava.view.impl;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.blackdread.sqltojava.entity.RelationType;
+import org.blackdread.sqltojava.entity.impl.JdlRelationImpl;
+import org.blackdread.sqltojava.view.JdlRelationView;
+
+@Immutable
+@ThreadSafe
+public class JdlRelationViewImpl extends JdlRelationImpl implements JdlRelationView {
+
+    /**
+     * Constructory based on super
+     * @param relationType
+     * @param bidirectional
+     * @param ownerRequired
+     * @param inverseSideRequired
+     * @param ownerEntityName
+     * @param inverseSideEntityName
+     * @param ownerRelationName
+     * @param ownerDisplayField
+     * @param ownerComment
+     * @param inverseSideComment
+     * @param inverseSideRelationName
+     * @param inverseSideDisplayField
+     * @param comment
+     */
+    public JdlRelationViewImpl(
+        RelationType relationType,
+        boolean bidirectional,
+        boolean ownerRequired,
+        boolean inverseSideRequired,
+        String ownerEntityName,
+        String inverseSideEntityName,
+        String ownerRelationName,
+        @Nullable String ownerDisplayField,
+        @Nullable String ownerComment,
+        @Nullable String inverseSideComment,
+        @Nullable String inverseSideRelationName,
+        @Nullable String inverseSideDisplayField,
+        @Nullable String comment
+    ) {
+        super(
+            relationType,
+            bidirectional,
+            ownerRequired,
+            inverseSideRequired,
+            ownerEntityName,
+            inverseSideEntityName,
+            ownerRelationName,
+            ownerDisplayField,
+            ownerComment,
+            inverseSideComment,
+            inverseSideRelationName,
+            inverseSideDisplayField,
+            comment
+        );
+    }
+}

--- a/src/main/java/org/blackdread/sqltojava/view/mapper/JdlViewMapper.java
+++ b/src/main/java/org/blackdread/sqltojava/view/mapper/JdlViewMapper.java
@@ -1,0 +1,20 @@
+package org.blackdread.sqltojava.view.mapper;
+
+import org.blackdread.sqltojava.config.UndefinedJdlTypeHandlingEnum;
+import org.blackdread.sqltojava.entity.impl.JdlEntityImpl;
+import org.blackdread.sqltojava.entity.impl.JdlFieldImpl;
+import org.blackdread.sqltojava.entity.impl.JdlRelationImpl;
+import org.blackdread.sqltojava.view.impl.JdlEntityViewImpl;
+import org.blackdread.sqltojava.view.impl.JdlFieldViewImpl;
+import org.blackdread.sqltojava.view.impl.JdlRelationViewImpl;
+import org.mapstruct.Mapper;
+
+/**
+ * Generate Mapstruct mapper sources on compile
+ */
+@Mapper(componentModel = "spring", uses = OptionalUtils.class)
+public interface JdlViewMapper {
+    JdlEntityViewImpl entityToView(JdlEntityImpl jdlEntity, UndefinedJdlTypeHandlingEnum undefinedJdlTypeHandling);
+    JdlFieldViewImpl fieldToView(JdlFieldImpl jdlField);
+    JdlRelationViewImpl relationToView(JdlRelationImpl jdlRelation);
+}

--- a/src/main/java/org/blackdread/sqltojava/view/mapper/OptionalUtils.java
+++ b/src/main/java/org/blackdread/sqltojava/view/mapper/OptionalUtils.java
@@ -1,0 +1,15 @@
+package org.blackdread.sqltojava.view.mapper;
+
+import java.util.Optional;
+
+/**
+ * Used to handle Optional with Mapstruct
+ */
+public class OptionalUtils {
+
+    private OptionalUtils() {}
+
+    public static <T> T fromOptional(Optional<T> optional) {
+        return optional.orElse(null);
+    }
+}

--- a/src/main/resources/mustache/application.mustache
+++ b/src/main/resources/mustache/application.mustache
@@ -1,0 +1,7 @@
+{{> entities}}
+
+// Relations
+{{> relations}}
+
+// Options
+{{> options}}

--- a/src/main/resources/mustache/entities.mustache
+++ b/src/main/resources/mustache/entities.mustache
@@ -1,0 +1,22 @@
+{{#entities}}
+{{^value.isPureManyToMany}}
+{{#value.comment}}
+{{value.docComment}}
+{{/value.comment}}
+{{#value.isReadOnly}}
+@readOnly
+{{/value.isReadOnly}}
+{{value.type}} {{value.name}}{{value.tableName}} {
+{{#value.filteredFields}}
+{{#value.comment}}
+    {{value.docComment}}
+{{/value.comment}}
+    {{value.name}} {{value.typeName}}{{value.constraints}}{{^last}},{{/last}}
+{{/value.filteredFields}}
+}
+{{^last}}{{/last}}
+{{/value.isPureManyToMany}}
+{{/entities}}
+{{^entities}}
+// No entities were found for which JDL is to be generated. Please review console logs
+{{/entities}}

--- a/src/main/resources/mustache/options.mustache
+++ b/src/main/resources/mustache/options.mustache
@@ -1,0 +1,3 @@
+{{#options}}
+{{value}}
+{{/options}}

--- a/src/main/resources/mustache/relations.mustache
+++ b/src/main/resources/mustache/relations.mustache
@@ -1,0 +1,24 @@
+{{#relations}}
+{{#value.isPureManyToMany}}
+// TODO This is a pure ManyToMany relation (delete me and decide owner side)
+{{/value.isPureManyToMany}}
+{{#value.comment}}
+{{value.implComment}}
+{{/value.comment}}
+relationship {{value.type}} {
+    {{^value.hasComments}}
+    {{value.ownerEntityName}}{{value.ownerConfig}} to {{value.inverseSideEntityName}}{{value.inverseConfig}}
+    {{/value.hasComments}}
+    {{#value.hasComments}}
+    {{#value.ownerDocComment}}
+    {{value.ownerDocComment}}
+    {{/value.ownerDocComment}}
+    {{value.ownerEntityName}}{{value.ownerConfig}} to
+    {{#value.inverseDocComment}}
+    {{value.inverseDocComment}}
+    {{/value.inverseDocComment}}
+    {{value.inverseSideEntityName}}{{value.inverseConfig}}
+    {{/value.hasComments}}
+}
+{{^last}}{{/last}}
+{{/relations}}

--- a/src/test/java/org/blackdread/sqltojava/shared/tests/SqlToJdlTransactionPerTestTest.java
+++ b/src/test/java/org/blackdread/sqltojava/shared/tests/SqlToJdlTransactionPerTestTest.java
@@ -2,7 +2,7 @@ package org.blackdread.sqltojava.shared.tests;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 import java.util.stream.Stream;
@@ -92,9 +92,9 @@ public abstract class SqlToJdlTransactionPerTestTest extends TransactionPerTestT
         );
 
         String expectedMessagePrefix = "Unsupported jdl type";
-        String actualMessage = exception.getMessage();
+        String actualMessage = exception.getCause().getMessage();
 
-        assumeTrue(actualMessage.startsWith(expectedMessagePrefix), actualMessage);
+        assertTrue(actualMessage.startsWith(expectedMessagePrefix), actualMessage);
     }
 
     /**

--- a/src/test/java/org/blackdread/sqltojava/test/general/MustacheTest.java
+++ b/src/test/java/org/blackdread/sqltojava/test/general/MustacheTest.java
@@ -1,0 +1,222 @@
+package org.blackdread.sqltojava.test.general;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import org.blackdread.sqltojava.config.ApplicationProperties;
+import org.blackdread.sqltojava.config.UndefinedJdlTypeHandlingEnum;
+import org.blackdread.sqltojava.entity.JdlFieldEnum;
+import org.blackdread.sqltojava.entity.JdlRelation;
+import org.blackdread.sqltojava.entity.RelationType;
+import org.blackdread.sqltojava.entity.impl.JdlEntityImpl;
+import org.blackdread.sqltojava.entity.impl.JdlFieldImpl;
+import org.blackdread.sqltojava.entity.impl.JdlRelationImpl;
+import org.blackdread.sqltojava.service.logic.MustacheService;
+import org.blackdread.sqltojava.util.JdlUtils;
+import org.blackdread.sqltojava.view.impl.JdlRelationViewImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { MustacheTest.MustacheServiceTestContextConfiguration.class })
+public class MustacheTest {
+
+    @TestConfiguration
+    static class MustacheServiceTestContextConfiguration {
+
+        @Bean
+        public MustacheService mustacheService() {
+            ApplicationProperties properties = mock(ApplicationProperties.class);
+            when(properties.getUndefinedTypeHandling()).thenReturn(UndefinedJdlTypeHandlingEnum.UNSUPPORTED);
+            return new MustacheService(properties);
+        }
+    }
+
+    @Autowired
+    private MustacheService mustacheService;
+
+    JdlFieldImpl p = new JdlFieldImpl(JdlFieldEnum.UUID, "id", true, null, null, null, null, null, false, false, true);
+    JdlFieldImpl f = new JdlFieldImpl(JdlFieldEnum.STRING, "abrev", true, null, 2, 6, null, null, false, true, false);
+    JdlEntityImpl b = new JdlEntityImpl("B", null, List.of(p, f), "Entity B comment", false, false, false, Collections.emptyList());
+    JdlRelationImpl relationWithComments = new JdlRelationViewImpl(
+        RelationType.ManyToOne,
+        true,
+        true,
+        false,
+        "A",
+        "B",
+        "a",
+        null,
+        "Owner comment",
+        "Inverse comment",
+        "b",
+        null,
+        "Relation comment"
+    );
+
+    JdlRelationImpl relationWithoutComments = new JdlRelationViewImpl(
+        RelationType.ManyToOne,
+        true,
+        true,
+        false,
+        "A",
+        "B",
+        "a",
+        null,
+        null,
+        null,
+        "b",
+        null,
+        null
+    );
+
+    JdlEntityImpl a = new JdlEntityImpl(
+        "A",
+        null,
+        List.of(p, f),
+        "Entity A comment",
+        false,
+        false,
+        false,
+        List.of(relationWithoutComments)
+    );
+
+    @Test
+    public void testEntity() {
+        String expected =
+            """
+            /** Entity A comment */
+            entity A {
+                id UUID,
+                abrev String required unique minlength(2) maxlength(6)
+            }
+
+            """;
+        Map<String, Object> context = new HashMap<>();
+        context.put("entities", List.of(a));
+        String result = mustacheService.executeTemplate("entities", context);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testRelation() {
+        String expected =
+            """
+            // Relation comment
+            relationship ManyToOne {
+                /** Owner comment */
+                A{a required} to
+                /** Inverse comment */
+                B{b}
+            }
+
+            """;
+        String result = mustacheService.executeTemplate("relations", Map.of("relations", List.of(relationWithComments)));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testRelationWithoutComments() {
+        String expected = """
+            relationship ManyToOne {
+                A{a required} to B{b}
+            }
+
+            """;
+        String result = mustacheService.executeTemplate("relations", Map.of("relations", List.of(relationWithoutComments)));
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testEntities() {
+        String expected =
+            """
+            /** Entity A comment */
+            entity A {
+                id UUID,
+                abrev String required unique minlength(2) maxlength(6)
+            }
+
+            /** Entity B comment */
+            entity B {
+                id UUID,
+                abrev String required unique minlength(2) maxlength(6)
+            }
+
+            """;
+        List<JdlEntityImpl> entities = Arrays.asList(a, b);
+        Map<String, Object> context = new HashMap<>();
+        context.put("entities", entities);
+
+        String result = mustacheService.executeTemplate("entities", context);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testNoEntities() {
+        String expected =
+            """
+            // No entities were found for which JDL is to be generated. Please review console logs
+            """;
+        List<JdlEntityImpl> entities = Collections.emptyList();
+        Map<String, Object> context = new HashMap<>();
+        context.put("entities", entities);
+
+        String result = mustacheService.executeTemplate("entities", context);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    public void testApplication() {
+        String expected =
+            """
+                /** Entity A comment */
+                entity A {
+                    id UUID,
+                    abrev String required unique minlength(2) maxlength(6)
+                }
+
+                /** Entity B comment */
+                entity B {
+                    id UUID,
+                    abrev String required unique minlength(2) maxlength(6)
+                }
+
+
+
+                // Relations
+                relationship ManyToOne {
+                    A{a required} to B{b}
+                }
+
+
+
+                // Options
+                service * with serviceClass
+                paginate * with pagination
+                dto * with mapstruct
+                filter *
+
+                """;
+        List<JdlEntityImpl> entities = Arrays.asList(a, b);
+        List<JdlRelation> relations = entities.stream().flatMap(e -> e.getRelations().stream()).collect(Collectors.toList());
+
+        List<String> options = JdlUtils.getOptions();
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("entities", entities);
+        context.put("relations", relations);
+        context.put("options", options);
+
+        String result = mustacheService.executeTemplate("application", context);
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/src/test/resources/jdl/enum-expected.jdl
+++ b/src/test/resources/jdl/enum-expected.jdl
@@ -8,7 +8,8 @@ entity City {
 }
 
 /** city_status comment */
-enum CityStatus {}
+enum CityStatus {
+}
 
 
 

--- a/src/test/resources/jdl/prune-expected.jdl
+++ b/src/test/resources/jdl/prune-expected.jdl
@@ -1,4 +1,5 @@
-entity Demo
+entity Demo {
+}
 
 
 


### PR DESCRIPTION
The PR is ready for review and fixes https://github.com/Blackdread/sql-to-jdl/issues/153.

I created some view objects that extend the Jdl*Impl classes.  These are mapped using MapStruct.

The view objects also have their own interfaces which is where the formatting methods from JdlUtils went.
